### PR TITLE
Customize 'images' for non built-in type : Imagestreams

### DIFF
--- a/deploy/dev/kustomization.yaml
+++ b/deploy/dev/kustomization.yaml
@@ -8,4 +8,4 @@ patches:
 # consumed with base's imagestream.yaml
 images:
   - name: nodejs-ex # match images with this name
-    newName: nodejs-dev # override the name
+    newName: nodejs-ex-dev # override the name

--- a/deploy/dev/kustomization.yaml
+++ b/deploy/dev/kustomization.yaml
@@ -3,4 +3,9 @@ bases:
 
 patches:
   - service_port.yaml
-  - buildconfig.yaml
+  - buildconfig.yaml 
+
+# consumed with base's imagestream.yaml
+images:
+  - name: nodejs-ex # match images with this name
+    newName: nodejs-dev # override the name

--- a/deploy/template/nodejs-ex-k/kustomization.yaml
+++ b/deploy/template/nodejs-ex-k/kustomization.yaml
@@ -4,3 +4,7 @@ commonLabels:
 resources:
   - templates/service.yaml
   - templates/buildconfig.yaml
+  - templates/imagestream.yaml
+
+configurations: 
+  - kustomizeconfig/imagestream.yaml

--- a/deploy/template/nodejs-ex-k/kustomization.yaml
+++ b/deploy/template/nodejs-ex-k/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 
 configurations: 
   - kustomizeconfig/imagestream.yaml
+  - kustomizeconfig/buildconfig.yaml
+  - kustomizeconfig/deploymentconfig.yaml

--- a/deploy/template/nodejs-ex-k/kustomizeconfig/buildconfig.yaml
+++ b/deploy/template/nodejs-ex-k/kustomizeconfig/buildconfig.yaml
@@ -1,0 +1,6 @@
+images:
+- path: spec/strategy/sourceStrategy/from/name
+  kind: BuildConfig
+- path: spec/output/to/name
+  kind: BuildConfig
+

--- a/deploy/template/nodejs-ex-k/kustomizeconfig/deploymentconfig.yaml
+++ b/deploy/template/nodejs-ex-k/kustomizeconfig/deploymentconfig.yaml
@@ -1,0 +1,3 @@
+images:
+  - path: spec/spec/containers/image
+    kind: DeploymentConfig

--- a/deploy/template/nodejs-ex-k/kustomizeconfig/imagestream.yaml
+++ b/deploy/template/nodejs-ex-k/kustomizeconfig/imagestream.yaml
@@ -1,0 +1,3 @@
+images:
+- path: spec/tags/from/name
+  kind: ImageStream

--- a/deploy/template/nodejs-ex-k/templates/buildconfig.yaml
+++ b/deploy/template/nodejs-ex-k/templates/buildconfig.yaml
@@ -24,7 +24,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: "nodejs-example:latest"
+      name: nodejs-ex:latest
   triggers:
   - type: ImageChange
   - type: ConfigChange

--- a/deploy/template/nodejs-ex-k/templates/imagestream.yaml
+++ b/deploy/template/nodejs-ex-k/templates/imagestream.yaml
@@ -2,5 +2,9 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
   name: "nodejs-example"
-  annotations:
-    description: Keeps track of changes in the application image
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: nodejs-ex


### PR DESCRIPTION
- add a `${BASE}/kustomizeconfig/imagestream.yaml`  file to specify _where_ to look for `image`s.
- update   ${BASE}/kustomize.yaml` to specify that we have new information a.k.a 'configuration'
```
configurations: 
  - kustomizeconfig/imagestream.yaml
```

- update `dev/kustomize.yaml` with image re-write rules ( "Use a specific image in dev!" )


Running a `make deploy-dev` / `kustomize build deploy/dev` gives us a 

```
apiVersion: image.openshift.io/v1
kind: ImageStream
metadata:
  labels:
    app: nodejs-ex-kustomize
  name: nodejs-example
spec:
  tags:
  - from:
      kind: DockerImage
      name: nodejs-ex-dev
    name: latest
```

Note, the `DockerImage` here is `nodejs-ex-dev` instead of the base's `nodejs-ex`. 


while running a 
`kustomize build deploy/stage` gives us

```
apiVersion: image.openshift.io/v1
kind: ImageStream
metadata:
  labels:
    app: nodejs-ex-kustomize
  name: nodejs-example
spec:
  tags:
  - from:
      kind: DockerImage
      name: nodejs-ex
    name: latest
```

