### PR TITLE
update node:8 to support in openshift 4

### DIFF
--- a/deploy/template/nodejs-ex-k/templates/buildconfig.yaml
+++ b/deploy/template/nodejs-ex-k/templates/buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
       from:
         kind: ImageStreamTag
         namespace: "openshift"
-        name: nodejs:6
+        name: nodejs:8
       env:
       - name: NPM_MIRROR
         value: 


### PR DESCRIPTION
node:6 builder image isn't available in openshift 4